### PR TITLE
add rule for ===

### DIFF
--- a/index.js
+++ b/index.js
@@ -14,6 +14,7 @@ module.exports = {
   rules: {
     'comma-dangle': [2, 'always-multiline'],
     'eol-last': 2,
+    'eqeqeq': 2,
     'indent': [2, 2, {SwitchCase: 1}],
     'linebreak-style': [2, 'unix'],
     'no-console': [1, {allow: ['info', 'warn', 'error']}],


### PR DESCRIPTION
http://eslint.org/docs/rules/eqeqeq

"It is considered good practice to use the type-safe equality operators `===` and `!==` instead of their regular counterparts `==` and `!=`.

The reason for this is that `==` and `!=` do type coercion which follows the rather obscure Abstract Equality Comparison Algorithm. For instance, the following statements are all considered true:
- `[] == false`
- `[] == ![]`
- `3 == "03"`

If one of those occurs in an innocent-looking statement such as `a == b` the actual problem is very difficult to spot."
