### PR TITLE
enforce camelCase

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,6 +12,7 @@ module.exports = {
   },
 
   rules: {
+    'camelcase': [2, {'properties': 'always'}],
     'comma-dangle': [2, 'always-multiline'],
     'eol-last': 2,
     'eqeqeq': 2,


### PR DESCRIPTION
if IRB with all its API calls and JQL had only 10 transgressions,
then I think we can safely default to camelz.
