### PR TITLE
tighten up that style some more

### DIFF
--- a/index.js
+++ b/index.js
@@ -24,7 +24,7 @@ module.exports = {
     'no-debugger': 1,
     'no-unused-expressions': 2,
     'no-use-before-define': [2, {classes: false}],
-    'quotes': [2, 'single'],
+    'quotes': [2, 'backtick'],
     'semi': [2, 'always'],
     'space-before-blocks': [2, 'always'],
   },

--- a/index.js
+++ b/index.js
@@ -25,5 +25,6 @@ module.exports = {
     'no-use-before-define': [2, {classes: false}],
     'quotes': [2, 'single'],
     'semi': [2, 'always'],
+    'space-before-blocks': [2, 'always'],
   },
 };

--- a/index.js
+++ b/index.js
@@ -12,6 +12,7 @@ module.exports = {
   },
 
   rules: {
+    'arrow-parens': [2, 'as-needed'],
     'camelcase': [2, {'properties': 'always'}],
     'comma-dangle': [2, 'always-multiline'],
     'eol-last': 2,


### PR DESCRIPTION
In order from least to most controversial:
- [spaces before braces, bros before joes](http://eslint.org/docs/rules/space-before-blocks)
- [no => parens for single-arg arrow funcs](http://eslint.org/docs/rules/arrow-parens)
- [template strings...everywhere](https://ponyfoo.com/articles/template-literals-strictly-better-strings)

Backticks errwhere can be a pretty brutal diff, but eslint seems to do a good job of automating the fix: https://github.com/mixpanel-platform/irb/compare/lint
