### PR TITLE
comma-spacing rule

### DIFF
--- a/index.js
+++ b/index.js
@@ -15,6 +15,7 @@ module.exports = {
     'arrow-parens': [2, 'as-needed'],
     'camelcase': [2, {'properties': 'always'}],
     'comma-dangle': [2, 'always-multiline'],
+    'comma-spacing': [2, {'before': false, 'after': true}],
     'eol-last': 2,
     'eqeqeq': 2,
     'indent': [2, 2, {SwitchCase: 1}],


### PR DESCRIPTION
thx @rickydoar !

http://eslint.org/docs/rules/comma-spacing
bad: `['foo','bar']`
good: `['foo', 'bar']`
