### PR TITLE
disallow superfluous spaces in object literals

### DIFF
--- a/index.js
+++ b/index.js
@@ -26,6 +26,7 @@ module.exports = {
     'multiline-ternary':           ['error', 'never'],
     'no-unused-expressions':       ['error'],
     'no-use-before-define':        ['error', {classes: false}],
+    'object-curly-spacing':        ['error', 'never'],
     'object-shorthand':            ['error', 'always'],
     'quotes':                      ['error', 'backtick'],
     'semi':                        ['error', 'always'],


### PR DESCRIPTION
http://eslint.org/docs/rules/object-curly-spacing
`{ foo: 'bar' } => {foo: 'bar'}`

Controversially forces imports and destructuring to be space-free:
```js
import {Component} from 'panel';
```
which I'm not a fan of but IMO still worth it for automating away nitpicks about the first case (`{ foo: 'bar'        }`).