### PR TITLE
Use ECMAScript 2017 parser option

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,7 +7,7 @@ module.exports = {
   extends: 'eslint:recommended',
 
   parserOptions: {
-    ecmaVersion: 6,
+    ecmaVersion: 8,
     sourceType: 'module',
   },
 

--- a/index.js
+++ b/index.js
@@ -7,7 +7,7 @@ module.exports = {
   extends: 'eslint:recommended',
 
   parserOptions: {
-    ecmaVersion: 8,
+    ecmaVersion: 2017,
     sourceType: 'module',
   },
 


### PR DESCRIPTION
The desired result of this is the ability to lint our tests, which rely on `async` functions. See [here](https://github.com/eslint/eslint/issues/8126).