### PR TITLE
Require use of the second argument for parseInt()

### DIFF
--- a/index.js
+++ b/index.js
@@ -29,6 +29,7 @@ module.exports = {
     'object-curly-spacing':        ['error', 'never'],
     'object-shorthand':            ['error', 'always'],
     'quotes':                      ['error', 'backtick'],
+    'radix':                       ['error'],
     'semi':                        ['error', 'always'],
     'space-before-blocks':         ['error', 'always'],
     'space-before-function-paren': ['error', 'never'],


### PR DESCRIPTION
Adopting a rule from the [Airbnb recommended set](https://github.com/airbnb/javascript/blob/57ff032b0740ba2a46af4bc40cf5638a3e62a365/packages/eslint-config-airbnb-base/rules/best-practices.js#L275) that requires use of the radix argument when using `parseInt`. Per [MDN](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/parseInt): 
>Always specify this parameter to eliminate reader confusion and to guarantee predictable behavior. Different implementations produce different results when a radix is not specified, usually defaulting the value to 10.

There are probably not all too many places where we use `parseInt` but would be nice to guarantee predictable behavior where we do.