### PR TITLE
Throw error on trailing spaces

### DIFF
--- a/index.js
+++ b/index.js
@@ -24,6 +24,7 @@ module.exports = {
     'indent':                      [`error`, 2, {SwitchCase: 1}],
     'linebreak-style':             [`error`, `unix`],
     'multiline-ternary':           [`error`, `never`],
+    'no-trailing-spaces':          [`error`],
     'no-unused-expressions':       [`error`],
     'no-use-before-define':        [`error`, {classes: false}],
     'object-curly-spacing':        [`error`, `never`],


### PR DESCRIPTION
See https://eslint.org/docs/rules/no-trailing-spaces. This rule is autofixable, which is nice.