### PR TITLE
Add stylint config

### DIFF
--- a/.stylintrc
+++ b/.stylintrc
@@ -1,0 +1,10 @@
+{
+  "colons": "never",
+  "groupOutputByFile": true,
+  "indentPref": 2,
+  "prefixVarsWithDollar": false,
+  "quotePref": "single",
+  "semicolons": "never",
+  "sortOrder": "alphabetical",
+  "valid": false
+}

--- a/.stylintrc
+++ b/.stylintrc
@@ -1,10 +1,11 @@
 {
   "colons": "never",
-  "groupOutputByFile": true,
   "indentPref": 2,
-  "prefixVarsWithDollar": false,
+  "prefixVarsWithDollar": true,
   "quotePref": "single",
   "semicolons": "never",
   "sortOrder": "alphabetical",
-  "valid": false
+  "trailingWhitespace": "never",
+  "valid": false,
+  "zeroUnits": "never"
 }

--- a/package.json
+++ b/package.json
@@ -18,7 +18,10 @@
   },
   "homepage": "https://github.com/mixpanel/eslint-config",
   "peerDependencies": {
-    "eslint": ">=3.1.0 <5.0.0",
+    "eslint": ">=3.1.0 <5.0.0"
+  },
+  "optionalDependencies": {
+    "stylint": ">=1.5.0 <2.0.0",
     "tslint": ">=5.0.0 <6.0.0"
   }
 }


### PR DESCRIPTION
Add a stylint config along with our ESLint and TSLint configs, and list it as an optional dependency so that we suppress warnings for projects that don't use TS and don't want to use TSLint just yet.

See https://github.com/SimenB/stylint#custom-configuration for more on stylint custom configuration.