### PR TITLE
require space between async keyword and arrow function parens

### DIFF
--- a/index.js
+++ b/index.js
@@ -32,6 +32,6 @@ module.exports = {
     'quotes':                      [`error`, `backtick`],
     'semi':                        [`error`, `always`],
     'space-before-blocks':         [`error`, `always`],
-    'space-before-function-paren': [`error`, `never`],
+    'space-before-function-paren': [`error`, {anonymous: `never`, named: `never`, asyncArrow: `always`}],
   },
 };


### PR DESCRIPTION
https://eslint.org/docs/rules/space-before-function-paren

For cases like:
```js
{
  myArrowFunc: async () => await foo(),
}
```

The existing config rejects that, which is pretty gnarly IMO.