### PR TITLE
Change stylintrc - zeroUnits:false

### DIFF
--- a/.stylintrc
+++ b/.stylintrc
@@ -1,4 +1,5 @@
 {
+  "brackets": "never",
   "colons": "never",
   "indentPref": 2,
   "prefixVarsWithDollar": true,
@@ -7,5 +8,5 @@
   "sortOrder": "alphabetical",
   "trailingWhitespace": "never",
   "valid": false,
-  "zeroUnits": "never"
+  "zeroUnits": "always"
 }

--- a/.stylintrc
+++ b/.stylintrc
@@ -8,5 +8,5 @@
   "sortOrder": "alphabetical",
   "trailingWhitespace": "never",
   "valid": false,
-  "zeroUnits": "always"
+  "zeroUnits": false
 }


### PR DESCRIPTION
Prefer linear-gradient(0deg, blue-100 0%, blue-200 100%)

over linear-gradient(0, blue-100 0, blue-200 100)

The units definitely make it more readable.

Also adding brackets: "never" explicitly so we can use a formatter like https://thisismanta.github.io/stylus-supremacy/#command-line to auto-fix stylus issue enmasse.

