### PR TITLE
Only single line ternary allowed

### DIFF
--- a/index.js
+++ b/index.js
@@ -26,7 +26,7 @@ module.exports = {
     'keyword-spacing':             [`error`],
     'linebreak-style':             [`error`, `unix`],
     'no-multi-spaces':             ['error', {exceptions: {Property: true }}],
-    'multiline-ternary':           [`error`, `always-multiline`],
+    'multiline-ternary':           [`error`, `never`],
     'no-trailing-spaces':          [`error`],
     'no-unused-expressions':       [`error`],
     'no-use-before-define':        [`error`, {classes: false}],


### PR DESCRIPTION
In response to internal discussion.

[Reference](https://eslint.org/docs/rules/multiline-ternary).

Will update on the platform-apps and analytics repo if this is approved.