### PR TITLE
Update tslint array-type to be array-simple

### DIFF
--- a/tslint-config.js
+++ b/tslint-config.js
@@ -1,8 +1,9 @@
+// Rules documentation: https://palantir.github.io/tslint/rules/
 module.exports = {
   extends: `tslint:recommended`,
   defaultSeverity: `error`,
   rules: {
-    'array-type': [true, `generic`],
+    'array-type': [true, `array-simple`],
     'arrow-parens': false,
     'arrow-return-shorthand': true,
     'import-spacing': true,


### PR DESCRIPTION
So rather than `Array<string>` we can just write `string[]`

Kind of how we've been doing it in jsdocs. It's also what typescript and vscode output shows when they infer types. It's terse and less typing. It's also what most TS code does in the open.