### PR TITLE
tslint: semicolons in interfaces too

### DIFF
--- a/tslint-config.js
+++ b/tslint-config.js
@@ -17,7 +17,7 @@ module.exports = {
     'no-invalid-template-strings': true,
     'only-arrow-functions': [false],
     'quotemark': [true, `single`, `avoid-escape`],
-    'semicolon': [true, `always`, `ignore-interfaces`],
+    'semicolon': [true, `always`],
     'switch-default': true,
   },
 };


### PR DESCRIPTION
We've been inconsistent with commas and semicolons. Sometimes in the same file due to multiple authors touching it.

This makes things stricter but more consistent.