### PR TITLE
Use types instead of interface

### DIFF
--- a/index.js
+++ b/index.js
@@ -21,6 +21,7 @@ module.exports = {
     'comma-spacing':               [`error`, {'before': false, 'after': true}],
     'eol-last':                    [`error`],
     'eqeqeq':                      [`error`],
+    'interface-over-type-literal': [`off`],
     'indent':                      [`error`, 2, {SwitchCase: 1}],
     'key-spacing':                 ['error', {beforeColon: false, afterColon: true, mode: `minimum`}],
     'keyword-spacing':             [`error`],

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "eslint-config-mixpanel",
   "description": "Mixpanel JavaScript style",
-  "version": "3.5.7",
+  "version": "3.5.8",
   "main": "index.js",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Based on discussion in #iron channel on June 13, 2019.

Now that we can extend types in typescript, it is better to use types instead of interfaces, because types of the same name cause an error to be thrown. Interfaces of the same name get merged instead of throwing an error which can cause unexpected results.